### PR TITLE
feat: run service without kafka

### DIFF
--- a/app/infrastructure/adapters/messaging/noop_publisher.py
+++ b/app/infrastructure/adapters/messaging/noop_publisher.py
@@ -1,0 +1,14 @@
+from app.core.domain.entities import VehicleEvent
+from app.core.ports.event_publisher import EventPublisher
+
+
+class NoOpEventPublisher(EventPublisher):
+    async def start(self) -> None:
+        print("⚠️ Kafka disabled: no-op start")
+
+    async def stop(self) -> None:
+        print("⚠️ Kafka disabled: no-op stop")
+
+    async def publish_processed_event(self, event: VehicleEvent) -> None:
+        # Log the event locally instead of publishing to Kafka
+        print(f"📤 [NoOpEventPublisher] {event}")


### PR DESCRIPTION
## Summary
- add NoOpEventPublisher to allow running without Kafka
- wire NoOpEventPublisher in dependency setup

## Testing
- `SKIP=isort,black pre-commit run --files app/infrastructure/dependencies.py app/infrastructure/adapters/messaging/noop_publisher.py`
- `uvicorn app.main:app --lifespan off --port 8000`


------
https://chatgpt.com/codex/tasks/task_e_6899f9ae1dc8833282d8aa03132d2c3c