### PR TITLE
Add unit and integration tests

### DIFF
--- a/app/infrastructure/adapters/api/routes.py
+++ b/app/infrastructure/adapters/api/routes.py
@@ -63,7 +63,7 @@ async def process_vehicle_event_api(
         address=request.address_,
         city=request.city_,
         department=request.department_,
-        fechakeep=request.fechakeep
+        keep_alive_date=request.fechakeep
     )
 
     try:

--- a/tests/integration/test_process_vehicle_event_api.py
+++ b/tests/integration/test_process_vehicle_event_api.py
@@ -1,0 +1,68 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+from asgi_lifespan import LifespanManager
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+# Set required environment variables before importing the app
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://user:pass@localhost/db")
+os.environ.setdefault("Maps_API_KEY", "test")
+os.environ.setdefault("API_KEY", "test-key")
+
+from app.main import app  # noqa: E402
+from app.infrastructure.dependencies import get_vehicle_event_processor_service
+
+
+class DummyService:
+    async def process_event(self, event):
+        return "processed"
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies():
+    async def _get_service():
+        return DummyService()
+
+    app.dependency_overrides[get_vehicle_event_processor_service] = _get_service
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_process_vehicle_event_endpoint():
+    payload = {
+        "tipo": 0,
+        "idveh": "veh1",
+        "idevento_": 2,
+        "fechasys_": "2024-01-01T00:00:00",
+        "speed": 10.0,
+        "lat": "N10.0",
+        "lon": "W074.0",
+        "odometer": 123.4,
+        "ip": "127.0.0.1",
+        "port": 8080,
+        "indexgeocerca": 1,
+        "vehicleon_": True,
+        "signal_": "OK",
+        "realtime_": "2024-01-01T00:00:00",
+        "address_": "Main St",
+        "city_": "Town",
+        "department_": "State",
+        "fechakeep": "2024-01-01T00:00:00",
+    }
+
+    async with LifespanManager(app):
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.post(
+                "/vehicle-events/process-vehicle-event",
+                json=payload,
+                headers={"X-API-Key": "test-key"},
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "OK"
+            assert data["message"] == "processed"

--- a/tests/unit/test_vehicle_event_utils.py
+++ b/tests/unit/test_vehicle_event_utils.py
@@ -1,0 +1,34 @@
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from app.core.services.vehicle_event_processor_service import (
+    _parse_coord_string,
+    _calculate_distance,
+    _calculate_bearing,
+)
+
+
+def test_parse_coord_string_valid():
+    assert _parse_coord_string("N10.12345") == pytest.approx(10.12345)
+    assert _parse_coord_string("W074.12345") == pytest.approx(-74.12345)
+
+
+def test_parse_coord_string_invalid():
+    assert _parse_coord_string(None) is None
+    assert _parse_coord_string("") is None
+    assert _parse_coord_string("NABC") is None
+
+
+def test_calculate_distance():
+    # Distance between two points about 111 km apart along equator
+    dist = _calculate_distance(0, 0, 0, 1)
+    assert dist == pytest.approx(111195, rel=1e-3)
+
+
+def test_calculate_bearing():
+    # Bearing from origin to point directly north should be 0 degrees
+    bearing = _calculate_bearing(0, 0, 1, 0)
+    assert bearing == 0


### PR DESCRIPTION
## Summary
- fix route to map `fechakeep` into `keep_alive_date`
- add unit tests for coordinate parsing, distance and bearing helpers
- add integration test for vehicle event processing endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f507ca9108332aea58cffe2047cd9