### PR TITLE
Fix test warnings

### DIFF
--- a/app/infrastructure/adapters/api/schemas.py
+++ b/app/infrastructure/adapters/api/schemas.py
@@ -23,5 +23,6 @@ class VehicleEventRequest(BaseModel):
     fechakeep: datetime = Field(..., description="Fecha de keep-alive (fecha de respaldo)")
 
 class VehicleEventResponse(BaseModel):
-    status: str = Field(..., example="OK")
+    status: str = Field(..., json_schema_extra={"example": "OK"})
     message: Optional[str] = None
+

--- a/app/infrastructure/adapters/database/models.py
+++ b/app/infrastructure/adapters/database/models.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String, BigInteger, Float, DateTime, Boolean, text, Date
 from sqlalchemy.dialects.postgresql import ENUM
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import relationship
 import geoalchemy2 as ga # For geometry types
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ pytest-mock
 pytest-cov
 asgi-lifespan
 httpx
+python-multipart
 testcontainers[postgresql]
 aiokafka~=0.8.1
 kafka-python==2.0.2


### PR DESCRIPTION
## Summary
- remove deprecated Field usage in schema
- update SQLAlchemy declarative base import
- switch integration test to ASGITransport and add python-multipart alias
- include python-multipart in dev requirements

## Testing
- `pytest tests/unit`
- `pytest tests/integration`


------
https://chatgpt.com/codex/tasks/task_e_689f5490f9f08332b9f08c27cc0a9ccf