### PR TITLE
Use remote PostgreSQL and fix EventosResumen mapping

### DIFF
--- a/app/core/domain/entities.py
+++ b/app/core/domain/entities.py
@@ -1,35 +1,44 @@
-from datetime import datetime
+from datetime import date, datetime
+from typing import Optional
+
 from pydantic import BaseModel, Field
-from typing import Optional, List
+
 
 class GeolocationInfo(BaseModel):
     address: Optional[str] = None
     city: Optional[str] = None
     department: Optional[str] = None
-    
+
     def is_valid(self) -> bool:
-        return self.address is not None and self.city is not None and self.department is not None and \
-               self.address != 'No Disponible' and self.city != 'No Disponible' and self.department != 'No Disponible'
+        return (
+            self.address is not None
+            and self.city is not None
+            and self.department is not None
+            and self.address != "No Disponible"
+            and self.city != "No Disponible"
+            and self.department != "No Disponible"
+        )
+
 
 class VehicleEvent(BaseModel):
-    event_type: int # tipo in SP (0, 300, 128)
-    vehicle_id: str = Field(..., max_length=50) # idveh
-    event_code: int = Field(..., ge=0) # idevento_
-    system_date_str: str # fechasys_
+    event_type: int  # tipo in SP (0, 300, 128)
+    vehicle_id: str = Field(..., max_length=50)  # idveh
+    event_code: int = Field(..., ge=0)  # idevento_
+    system_date_str: str  # fechasys_
     speed: float = Field(..., ge=0)
-    latitude_raw: str # lat (e.g., 'N10.12345')
-    longitude_raw: str # lon (e.g., 'W074.12345')
+    latitude_raw: str  # lat (e.g., 'N10.12345')
+    longitude_raw: str  # lon (e.g., 'W074.12345')
     odometer: Optional[float] = None
     ip_address: str
     port: int
-    geofence_index: Optional[int] = None # indexgeocerca
-    vehicle_on: Optional[bool] = None # vehicleon_ (signal for ignition)
-    signal_status: Optional[str] = None # signal_ (e.g., 'OK', 'NOK')
-    realtime_date: Optional[datetime] = None # realtime_
-    address: Optional[str] = None # address_ (from modem if available)
-    city: Optional[str] = None # city_ (from modem if available)
-    department: Optional[str] = None # department_ (from modem if available)
-    keep_alive_date: datetime # fechakeep (fallback date)
+    geofence_index: Optional[int] = None  # indexgeocerca
+    vehicle_on: Optional[bool] = None  # vehicleon_ (signal for ignition)
+    signal_status: Optional[str] = None  # signal_ (e.g., 'OK', 'NOK')
+    realtime_date: Optional[datetime] = None  # realtime_
+    address: Optional[str] = None  # address_ (from modem if available)
+    city: Optional[str] = None  # city_ (from modem if available)
+    department: Optional[str] = None  # department_ (from modem if available)
+    keep_alive_date: datetime  # fechakeep (fallback date)
 
     # Calculated fields, not part of input directly
     processed_latitude: Optional[float] = None
@@ -39,10 +48,11 @@ class VehicleEvent(BaseModel):
     geolocation: Optional[GeolocationInfo] = None
     is_static_event: Optional[bool] = False
     is_ignition_event: Optional[bool] = False
-    period_id: Optional[int] = None # idperiodo_
-    ignition_status: Optional[str] = None # enc_apa_
-    current_driver_id: Optional[int] = None # idconductor_
-    event_db_id: Optional[int] = None # idevt
+    period_id: Optional[int] = None  # idperiodo_
+    ignition_status: Optional[str] = None  # enc_apa_
+    current_driver_id: Optional[int] = None  # idconductor_
+    event_db_id: Optional[int] = None  # idevt
+
 
 class Vehicle(BaseModel):
     idvehiculo: str
@@ -69,14 +79,17 @@ class Vehicle(BaseModel):
     contratista: Optional[str] = None
     recurso: Optional[str] = None
 
+
 class EventoDescripcion(BaseModel):
     evento: str
-    estatico: Optional[str] = 'N' # 'S' for static, 'N' for not
+    estatico: Optional[str] = "N"  # 'S' for static, 'N' for not
+
 
 class Proceso(BaseModel):
     proceso: str
     contratistas: str
     toleranciatiempo: int
+
 
 class PeriodoActivo(BaseModel):
     idperiodo: int
@@ -85,12 +98,14 @@ class PeriodoActivo(BaseModel):
     fechahasta: Optional[datetime] = None
     idconductor: Optional[int] = None
 
+
 class PeriodoConductor(BaseModel):
     idperiodo: int
     idvehiculo: str
     idconductor: int
     fechadesde: datetime
     fechahasta: Optional[datetime] = None
+
 
 class ProgramacionEspecialVehiculo(BaseModel):
     idprogramacion: int
@@ -101,17 +116,20 @@ class ProgramacionEspecialVehiculo(BaseModel):
     activa: str
     idruta: int
 
+
 class RutaEspecialDetalle(BaseModel):
     idruta: int
     idpunto: int
     orden: int
-    tiempoglobal: Optional[float] = None # tiempoglobal in SP
+    tiempoglobal: Optional[float] = None  # tiempoglobal in SP
+
 
 class PuntoControlEspecial(BaseModel):
     idpunto: int
     latitud: float
     longitud: float
     radio: float
+
 
 class RutaEspecialControl(BaseModel):
     idprogramacion: int
@@ -123,9 +141,10 @@ class RutaEspecialControl(BaseModel):
     diferenciaglobal: float
     orden: int
 
+
 class EventoResumen(BaseModel):
     idvehiculo: str
     idevento: int
     valor: int
-    fecha: datetime
+    fecha: date
     hora: int

--- a/app/infrastructure/adapters/database/models.py
+++ b/app/infrastructure/adapters/database/models.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     Float,
     Integer,
     Numeric,
+    SmallInteger,
     String,
     text,
 )
@@ -150,14 +151,11 @@ class Recursos(Base):
 
 class EventosResumen(Base):
     __tablename__ = "eventos_resumen"
-    id = Column(
-        BigInteger, primary_key=True, autoincrement=True
-    )  # Assuming primary key
-    idvehiculo = Column(String)
-    idevento = Column(Integer)
-    valor = Column(Integer)
-    fecha = Column(Date)
-    hora = Column(Integer)
+    idvehiculo = Column(String, primary_key=True)
+    idevento = Column(SmallInteger, primary_key=True)
+    valor = Column(BigInteger)
+    fecha = Column(Date, primary_key=True)
+    hora = Column(SmallInteger, primary_key=True)
 
 
 # Special Transport Tables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,15 +32,6 @@ services:
       - "8000:8000"
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
-      DATABASE_URL: postgresql+asyncpg://user:pass@postgres/vehicledb
+      DATABASE_URL: postgresql+asyncpg://jgalindo:jg4l1nd0_2025@experiment2025.cbfclvgzldks.us-east-1.rds.amazonaws.com:5432/xtrackcronos_des22
     volumes:
       - .:/app
-
-  postgres:
-    image: postgres:15
-    environment:
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: pass
-      POSTGRES_DB: vehicledb
-    ports:
-      - "5432:5432"


### PR DESCRIPTION
## Summary
- point FastAPI service to remote PostgreSQL and drop local container
- align EventosResumen ORM model with composite PK and proper column types
- adjust EventoResumen domain entity to use `date`

## Testing
- `pre-commit run --files docker-compose.yml app/infrastructure/adapters/database/models.py app/core/domain/entities.py`
- `API_KEY=test DATABASE_URL=postgresql+asyncpg://jgalindo:jg4l1nd0_2025@experiment2025.cbfclvgzldks.us-east-1.rds.amazonaws.com:5432/xtrackcronos_des22 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adb894d0f883328fd63d5b6880cefd