### PR TITLE
Remove exposed production database credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # VehicleEventMS
 Microservicio para registrar eventos de vehiculos
+
+## Configuración
+
+El servicio utiliza la variable de entorno `DATABASE_URL` para conectarse a la base de datos.
+Al ejecutar con `docker-compose` se usará automáticamente una base de datos local a menos que
+se proporcione un valor diferente. Para entornos de producción define esta variable de forma
+externa (por ejemplo en un archivo `.env`) y evita commitear credenciales al repositorio.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,6 @@ services:
       - "8000:8000"
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
-      DATABASE_URL: postgresql+asyncpg://jgalindo:jg4l1nd0_2025@experiment2025.cbfclvgzldks.us-east-1.rds.amazonaws.com:5432/xtrackcronos_des22
+      DATABASE_URL: ${DATABASE_URL:-postgresql+asyncpg://user:pass@postgres/vehicledb}
     volumes:
       - .:/app


### PR DESCRIPTION
## Summary
- avoid committing production PostgreSQL credentials by using a `DATABASE_URL` env var with a local default
- document database configuration and keeping secrets out of version control

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adcb51c1bc8332b2a8c5476ffe013a