### PR TITLE
Fix DB session lifecycle in dependencies

### DIFF
--- a/app/infrastructure/adapters/database/models.py
+++ b/app/infrastructure/adapters/database/models.py
@@ -26,7 +26,12 @@ class Vehiculos(Base):
     idvehiculo = Column(String, primary_key=True)
     estado = Column(String)  # 'Y' or 'N'
     tipo_modem = Column(String)
-    velocidad = Column(Float)
+    # In the production database, the "velocidad" column is stored as a VARCHAR
+    # even though the service expects a numeric value. Mapping it as a Float in
+    # SQLAlchemy causes asyncpg to try decoding the field as a numeric type and
+    # fail when it encounters the underlying VARCHAR OID (1043).  We map it as a
+    # String here and convert it to a float at the repository level.
+    velocidad = Column(String)
     direccion = Column(String)
     latitud = Column(String)
     longitud = Column(String)

--- a/app/infrastructure/adapters/database/repositories.py
+++ b/app/infrastructure/adapters/database/repositories.py
@@ -46,6 +46,14 @@ from app.infrastructure.adapters.database.models import (
 )
 
 
+def _parse_float(value: Optional[str]) -> Optional[float]:
+    """Safely convert a potentially null or non-numeric string to float."""
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
 # Helper function for converting ORM models to domain entities
 def _to_vehicle_entity(model: Vehiculos) -> Optional[Vehicle]:
     if not model:
@@ -54,7 +62,7 @@ def _to_vehicle_entity(model: Vehiculos) -> Optional[Vehicle]:
         idvehiculo=model.idvehiculo,
         estado=model.estado,
         tipo_modem=model.tipo_modem,
-        velocidad=model.velocidad,
+        velocidad=_parse_float(model.velocidad),
         direccion=model.direccion,
         latitud=model.latitud,
         longitud=model.longitud,


### PR DESCRIPTION
## Summary
- keep database session open for geolocation and event processor services
- provide services via async generators instead of returning closed sessions
- map vehiculos.velocidad as string to avoid asyncpg type error

## Testing
- `pytest tests/unit -q`
- `pytest tests/integration -q` *(fails: TypeError: str expected, not NoneType)*

------
https://chatgpt.com/codex/tasks/task_e_68aefe7eb64083329b17ce012a1b5f1b