### PR TITLE
Fix DB session lifecycle in dependencies

### DIFF
--- a/app/infrastructure/adapters/database/models.py
+++ b/app/infrastructure/adapters/database/models.py
@@ -26,7 +26,12 @@ class Vehiculos(Base):
     idvehiculo = Column(String, primary_key=True)
     estado = Column(String)  # 'Y' or 'N'
     tipo_modem = Column(String)
-    velocidad = Column(Float)
+    # In the production database, the "velocidad" column is stored as a VARCHAR
+    # even though the service expects a numeric value. Mapping it as a Float in
+    # SQLAlchemy causes asyncpg to try decoding the field as a numeric type and
+    # fail when it encounters the underlying VARCHAR OID (1043).  We map it as a
+    # String here and convert it to a float at the repository level.
+    velocidad = Column(String)
     direccion = Column(String)
     latitud = Column(String)
     longitud = Column(String)
@@ -79,7 +84,11 @@ class EventosDesc(Base):
 
 
 class Procesos(Base):
-    __tablename__ = "procesos"
+    # The table is stored in PostgreSQL with a capitalized name ("Procesos").
+    # SQLAlchemy requires the exact case to be specified so it can quote the
+    # identifier properly; otherwise the database looks for a lowercase table
+    # that doesn't exist.
+    __tablename__ = "Procesos"
     proceso = Column(String, primary_key=True)
     contratistas = Column(String)  # Regex string
     toleranciatiempo = Column(Integer)


### PR DESCRIPTION
## Summary
- keep database session open for geolocation and event processor services
- provide services via async generators instead of returning closed sessions
- map vehiculos.velocidad as string to avoid asyncpg type error
- map Procesos table with proper casing so queries find the table
- convert Vehicle.velocidad to string before persisting updates

## Testing
- `pytest tests/unit -q`
- `DATABASE_URL=postgresql+asyncpg://user:pass@localhost/db API_KEY=test pytest tests/integration -q`


------
https://chatgpt.com/codex/tasks/task_e_68aefe7eb64083329b17ce012a1b5f1b