### PR TITLE
fix: align Recursos model with database schema

### DIFF
--- a/app/infrastructure/adapters/database/models.py
+++ b/app/infrastructure/adapters/database/models.py
@@ -149,12 +149,20 @@ class Odométros(Base):
 
 class Recursos(Base):
     __tablename__ = "Recursos"  # Note the mixed case, adjust if needed
-    id = Column(
-        BigInteger, primary_key=True, autoincrement=True
-    )  # Assuming primary key
-    recurso = Column(String)
-    contratista = Column(String)
+    recurso = Column(String, primary_key=True)
+    contratista = Column(String, primary_key=True)
+    tiporecurso = Column(String)
+    nombre = Column(String)
+    estado = Column(String)
+    usuariomovil = Column(String)
+    clavemovil = Column(String)
+    estadomovil = Column(String)
+    latitud = Column(String)
+    longitud = Column(String)
     fechagps = Column(DateTime)
+    estadovehiculo = Column(String)
+    online = Column(String)
+    direccion = Column(String)
     estadogps = Column(String)  # 'OK' or 'NOTOK'
 
 


### PR DESCRIPTION
## Summary
- remove nonexistent `id` column from `Recursos` SQLAlchemy model
- define composite primary key and include remaining columns

## Testing
- `pre-commit run --files app/infrastructure/adapters/database/models.py`
- `pytest` *(fails: TypeError: str expected, not NoneType)*

------
https://chatgpt.com/codex/tasks/task_e_68af100de35883328a5813fe39cec189