### PR TITLE
fix: align recursos and odometros models with database schema

### DIFF
--- a/app/infrastructure/adapters/database/models.py
+++ b/app/infrastructure/adapters/database/models.py
@@ -139,22 +139,29 @@ class ProgramacionVehicularModel(
     activa = Column(String)  # 'S' or 'N'
 
 
-class Odométros(Base):
+class Odometros(Base):
     __tablename__ = "odometros"
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    idvehiculo = Column(String)
+    idvehiculo = Column(String, primary_key=True)
     valor = Column(Float)
-    fecha = Column(DateTime)
+    fecha = Column(DateTime, primary_key=True)
 
 
 class Recursos(Base):
     __tablename__ = "Recursos"  # Note the mixed case, adjust if needed
-    id = Column(
-        BigInteger, primary_key=True, autoincrement=True
-    )  # Assuming primary key
-    recurso = Column(String)
-    contratista = Column(String)
+    recurso = Column(String, primary_key=True)
+    contratista = Column(String, primary_key=True)
+    tiporecurso = Column(String)
+    nombre = Column(String)
+    estado = Column(String)
+    usuariomovil = Column(String)
+    clavemovil = Column(String)
+    estadomovil = Column(String)
+    latitud = Column(String)
+    longitud = Column(String)
     fechagps = Column(DateTime)
+    estadovehiculo = Column(String)
+    online = Column(String)
+    direccion = Column(String)
     estadogps = Column(String)  # 'OK' or 'NOTOK'
 
 

--- a/app/infrastructure/adapters/database/repositories.py
+++ b/app/infrastructure/adapters/database/repositories.py
@@ -32,7 +32,7 @@ from app.infrastructure.adapters.database.models import (
     Eventos,
     EventosDesc,
     EventosResumen,
-    Odométros,
+    Odometros,
     PeriodosActivo,
     PeriodosConductores,
     Procesos,
@@ -187,7 +187,7 @@ class VehicleEventRepositoryImpl(VehicleEventRepository):
         return new_event.idevento
 
     async def save_odometer(self, vehicle_id: str, value: float, date: datetime):
-        new_odometer = Odométros(idvehiculo=vehicle_id, valor=value, fecha=date)
+        new_odometer = Odometros(idvehiculo=vehicle_id, valor=value, fecha=date)
         self.session.add(new_odometer)
         await self.session.flush()
 
@@ -240,8 +240,15 @@ class VehicleEventRepositoryImpl(VehicleEventRepository):
                 keep_alive_date=event_model.fecha,  # Using event_model.fecha as fallback
             )
         return None
-      
-    async def insert_ejes_viales(self, address: str, city: str, latitude: float, longitude: float, department: str):
+
+    async def insert_ejes_viales(
+        self,
+        address: str,
+        city: str,
+        latitude: float,
+        longitude: float,
+        department: str,
+    ):
         print("ejes viales")
         new_entry = EjesViales(
             direccion=address,
@@ -308,6 +315,7 @@ class VehicleEventRepositoryImpl(VehicleEventRepository):
         self.session.add(new_summary)
         await self.session.flush()
 
+
 class VehicleRepositoryImpl(VehicleRepository):
     def __init__(self, session: AsyncSession):
         self.session = session
@@ -359,7 +367,6 @@ class VehicleRepositoryImpl(VehicleRepository):
             pass
 
     async def get_vehicle_tolerancia_tiempo(self, vehicle_contratista: str) -> int:
-
         # Example of a simplified regex matching for direct string comparison:
         stmt = (
             select(Procesos)
@@ -492,9 +499,9 @@ class SpecialRouteRepositoryImpl(SpecialRouteRepository):
         result = await self.session.execute(stmt)
         return _to_programacion_especial_vehiculo_entity(result.scalar_one_or_none())
 
-
-    async def get_nearby_special_route_detail(self, route_id: int, latitude: float, longitude: float) -> Optional[RutaEspecialDetalle]:
-
+    async def get_nearby_special_route_detail(
+        self, route_id: int, latitude: float, longitude: float
+    ) -> Optional[RutaEspecialDetalle]:
         current_point = func.ST_GeomFromText(f"POINT({longitude} {latitude})", 4326)
 
         stmt = (


### PR DESCRIPTION
## Summary
- remove nonexistent `id` column from `Recursos` SQLAlchemy model
- remove nonexistent `id` column and use `(idvehiculo, fecha)` as `odometros` composite primary key
- update repository to use new `Odometros` model

## Testing
- `pre-commit run --files app/infrastructure/adapters/database/models.py app/infrastructure/adapters/database/repositories.py`
- `pytest` *(fails: TypeError: str expected, not NoneType)*

------
https://chatgpt.com/codex/tasks/task_e_68af100de35883328a5813fe39cec189