### PR TITLE
feat: cache geolocation lookups to improve performance

### DIFF
--- a/app/infrastructure/adapters/geolocation/Maps_adapter.py
+++ b/app/infrastructure/adapters/geolocation/Maps_adapter.py
@@ -1,49 +1,104 @@
-from typing import Optional
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import text # Importar text para ejecutar SQL raw
+"""Geolocation adapter backed by PostgreSQL.
 
-from app.core.domain.services import GeolocationService
+This version adds a small in-memory cache to avoid hitting the database for
+coordinates that were recently resolved.  Many vehicles report events from the
+same location consecutively and the reverse geocoding query is expensive.  By
+keeping a simple LRU cache we can dramatically reduce average response times
+for those repeated lookups.
+"""
+
+from collections import OrderedDict
+from typing import Optional, Tuple
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.core.domain.entities import GeolocationInfo
+from app.core.domain.services import GeolocationService
+
+CacheType = OrderedDict[Tuple[float, float], GeolocationInfo]
+
 
 class PostgresGeolocationAdapter(GeolocationService):
-    def __init__(self, session: AsyncSession):
-        self.session = session
+    """Geolocation service using a PostgreSQL stored procedure.
 
-    async def get_address_from_coords(self, latitude: float, longitude: float) -> Optional[GeolocationInfo]:
+    Parameters
+    ----------
+    session:
+        Async SQLAlchemy session used to execute the ``getdireccion`` stored
+        procedure.
+    cache_size:
+        Maximum number of coordinates stored in the local cache.  When the
+        cache is full the least recently used entry is discarded.
+    """
+
+    def __init__(self, session: AsyncSession, cache_size: int = 128):
+        self.session = session
+        self.cache_size = cache_size
+        # Simple LRU cache for reverse geocoding lookups
+        self._cache: CacheType = OrderedDict()
+
+    async def get_address_from_coords(
+        self, latitude: float, longitude: float
+    ) -> Optional[GeolocationInfo]:
+        """Resolve coordinates into an address using ``getdireccion``.
+
+        A simple LRU cache is used so that consecutive requests for the same
+        coordinates return immediately without querying the database again.
+        Coordinates are rounded to 5 decimal places before caching to avoid
+        storing excessive keys for minimal variations.
         """
-        Realiza la geocodificación inversa llamando a la función PL/pgSQL getdireccion.
-        """
+
+        key = (round(latitude, 5), round(longitude, 5))
+        cached = self._cache.get(key)
+        if cached is not None:
+            # Move to the end to mark as recently used and return cached value
+            self._cache.move_to_end(key)
+            return cached
+
         try:
-            # Ejecutar la función getdireccion en PostgreSQL
-            # La función getdireccion devuelve un tipo compuesto (composite type) o un RECORD.
-            # Necesitamos mapear eso a nuestros campos.
-            # Asumiendo que getdireccion retorna una tupla o un record con campos like (direccion, municipio, departamento)
-            # El nombre de la función en el SP es getdireccion.
             query = text("SELECT * FROM getdireccion(:lat, :lon)")
-            
-            # Ejecutar la consulta y obtener el resultado
-            result = await self.session.execute(query, {"lat": latitude, "lon": longitude})
+            result = await self.session.execute(
+                query, {"lat": latitude, "lon": longitude}
+            )
             row = result.fetchone()
 
             if row:
-                # Acceder a los campos por índice o por nombre si es posible
-                # Asumo que la función getdireccion devuelve 3 columnas en este orden
-                # (direccion TEXT, municipio TEXT, departamento TEXT)
                 address = row[0] if len(row) > 0 else None
                 city = row[1] if len(row) > 1 else None
                 department = row[2] if len(row) > 2 else None
-                if address and address.lower() == 'no disponible':
+
+                if address and address.lower() == "no disponible":
                     address = None
-                if city and city.lower() == 'no disponible':
+                if city and city.lower() == "no disponible":
                     city = None
-                if department and department.lower() == 'no disponible':
+                if department and department.lower() == "no disponible":
                     department = None
 
-                return GeolocationInfo(address=address, city=city, department=department)
-            
-            return GeolocationInfo(address='No Disponible', city='No Disponible', department='No Disponible') # Default if no row
+                info = GeolocationInfo(
+                    address=address, city=city, department=department
+                )
+            else:
+                info = GeolocationInfo(
+                    address="No Disponible",
+                    city="No Disponible",
+                    department="No Disponible",
+                )
 
-        except Exception as e:
-            print(f"Error calling getdireccion in PostgreSQL: {e}")
-            # En caso de error, retorna un objeto con info 'No Disponible'
-            return GeolocationInfo(address='No Disponible', city='No Disponible', department='No Disponible')
+        except Exception as exc:  # pragma: no cover - log and return default
+            print(f"Error calling getdireccion in PostgreSQL: {exc}")
+            info = GeolocationInfo(
+                address="No Disponible",
+                city="No Disponible",
+                department="No Disponible",
+            )
+
+        # Maintain LRU cache
+        if key in self._cache:
+            self._cache.move_to_end(key)
+        else:
+            if len(self._cache) >= self.cache_size:
+                self._cache.popitem(last=False)
+            self._cache[key] = info
+
+        return info


### PR DESCRIPTION
## Summary
- cache reverse geocoding results in Postgres adapter to avoid repeated DB lookups

## Testing
- `pre-commit run --files app/infrastructure/adapters/geolocation/Maps_adapter.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b24a3db5b0833295412f54cb9d8d30